### PR TITLE
[#141] Fix warning on startup with dubbo2.6.4

### DIFF
--- a/dubbo-admin-backend/pom.xml
+++ b/dubbo-admin-backend/pom.xml
@@ -55,11 +55,27 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>dubbo</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>netty</artifactId>
+                    <groupId>org.jboss.netty</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>guava</artifactId>
+                    <groupId>com.google.guava</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>netty</artifactId>
+                    <groupId>io.netty</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
@@ -78,6 +94,10 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
 		<fastjson-version>1.2.46</fastjson-version>
 		<snakeyaml-version>1.22</snakeyaml-version>
 		<springfox-swagger-version>2.9.2</springfox-swagger-version>
+		<netty-version>4.1.30.Final</netty-version>
 	</properties>
 
 	<dependencyManagement>
@@ -89,6 +90,11 @@
 				<groupId>io.springfox</groupId>
 				<artifactId>springfox-swagger-ui</artifactId>
 				<version>${springfox-swagger-version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-all</artifactId>
+				<version>${netty-version}</version>
 			</dependency>
 
 		</dependencies>


### PR DESCRIPTION
* Exclude dependency `netty:3.x` for dubbo and curator-framework
* Add dependency `netty-all:4.1.30.Final`