### PR TITLE
代码重构，修复bug，加注释

### DIFF
--- a/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/controller/ServiceController.java
+++ b/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/controller/ServiceController.java
@@ -50,55 +50,10 @@ public class ServiceController {
     public Set<ServiceDTO> searchService(@RequestParam String pattern,
                                          @RequestParam String filter,@PathVariable String env) {
 
-        List<Provider> providers = new ArrayList<>();
-        if (!filter.contains("*") && !filter.contains("?")) {
-            if (pattern.equals("ip")) {
-                providers = providerService.findByAddress(filter);
-            } else if (pattern.equals("serviceName")) {
-                providers = providerService.findByService(filter);
-            } else if (pattern.equals("application")) {
-                providers = providerService.findByApplication(filter);
-            }
-        } else {
-            List<String> candidates = Collections.emptyList();
-            if (pattern.equals("serviceName")) {
-               candidates = providerService.findServices();
-            } else if (pattern.equals("application")) {
-                candidates = providerService.findApplications();
-            }
-            filter = filter.toLowerCase().replace(".", "\\.");
-            if (filter.startsWith("*")) {
-                filter = "." + filter;
-            }
-            Pattern regex = Pattern.compile(filter);
-            for (String candidate : candidates) {
-                Matcher matcher = regex.matcher(candidate);
-                if (matcher.matches() || matcher.lookingAt()) {
-                    if (pattern.equals("serviceName")) {
-                        providers.addAll(providerService.findByService(candidate));
-                    } else {
-                        providers.addAll(providerService.findByApplication(candidate));
-                    }
-                }
-            }
-        }
-
-        Set<ServiceDTO> result = new TreeSet<>();
-        for (Provider provider : providers) {
-            Map<String, String> map = StringUtils.parseQueryString(provider.getParameters());
-            String app = provider.getApplication();
-            String service = map.get(Constants.INTERFACE_KEY);
-            String group = map.get(Constants.GROUP_KEY);
-            String version = map.get(Constants.VERSION_KEY);
-            ServiceDTO s = new ServiceDTO();
-            s.setAppName(app);
-            s.setService(service);
-            s.setGroup(group);
-            s.setVersion(version);
-            result.add(s);
-        }
-        return result;
+        return providerService.getServiceDTOS(pattern, filter, env);
     }
+
+
 
     @RequestMapping(value = "/{service}", method = RequestMethod.GET)
     public ServiceDetailDTO serviceDetail(@PathVariable String service, @PathVariable String env) {

--- a/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/governance/service/ProviderService.java
+++ b/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/governance/service/ProviderService.java
@@ -16,13 +16,14 @@
  */
 package org.apache.dubbo.admin.governance.service;
 
+import org.apache.dubbo.admin.dto.ServiceDTO;
 import org.apache.dubbo.admin.registry.common.domain.Provider;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * ProviderService
- *
  */
 public interface ProviderService {
 
@@ -42,6 +43,11 @@ public interface ProviderService {
 
     Provider findProvider(String id);
 
+    /**
+     * Get all provider's service name
+     *
+     * @return list of all provider's service name
+     */
     List<String> findServices();
 
     List<String> findAddresses();
@@ -52,18 +58,36 @@ public interface ProviderService {
 
     List<String> findApplicationsByServiceName(String serviceName);
 
+    /**
+     * Get provider list with specific service name.
+     *
+     * @param serviceName specific service name, cannot be fuzzy string
+     * @return list of provider object
+     */
     List<Provider> findByService(String serviceName);
 
     List<Provider> findByAppandService(String app, String serviceName);
 
     List<Provider> findAll();
 
+    /**
+     * Get provider list with specific ip address.
+     *
+     * @param providerAddress provider's ip address
+     * @return list of provider object
+     */
     List<Provider> findByAddress(String providerAddress);
 
     List<String> findServicesByAddress(String providerAddress);
 
     List<String> findApplications();
 
+    /**
+     * Get provider list with specific application name.
+     *
+     * @param application specific application name
+     * @return list of provider object
+     */
     List<Provider> findByApplication(String application);
 
     List<String> findServicesByApplication(String application);
@@ -71,5 +95,18 @@ public interface ProviderService {
     List<String> findMethodsByService(String serviceName);
 
     Provider findByServiceAndAddress(String service, String address);
+
+    /**
+     * Get a set of service data object.
+     *
+     * ServiceDTO object contains base information include
+     * service name , application, group and version.
+     *
+     * @param pattern {@code String} type of search
+     * @param filter  {@code String} input filter string
+     * @param env     {@code String}the environment of front end
+     * @return a set of services for fore-end page
+     */
+    Set<ServiceDTO> getServiceDTOS(String pattern, String filter, String env);
 
 }

--- a/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/governance/util/WebConstants.java
+++ b/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/governance/util/WebConstants.java
@@ -40,9 +40,17 @@ public class WebConstants {
     /**
      * Service name
      */
-    public static final String SERVICE_NAME = "serviceName";
+    public static final String SERVICE_NAME_KEY = "serviceName";
     /**
-     * Service name
+     * application
+     */
+    public static final String APPLICATION_KEY = "application";
+    /**
+     * ip
+     */
+    public static final String IP_KEY = "ip";
+    /**
+     * entry
      */
     public static final String ENTRY = "entry";
     /**

--- a/dubbo-admin-frontend/src/components/ServiceSearch.vue
+++ b/dubbo-admin-frontend/src/components/ServiceSearch.vue
@@ -35,6 +35,7 @@
                   :suffix="queryBy"
                   :hint="hint"
                   label="Search Dubbo Services"
+                  @keyup.enter="submit"
                 ></v-combobox>
                   <v-menu class="hidden-xs-only">
                     <v-btn slot="activator" large icon>


### PR DESCRIPTION
1.把搜索功能从controller中抽出到service里,替换掉里面的魔法值
2.之前的模糊搜索，因为将filter强制转换成小写了，所以*ExampleService这样的搜索条件搜不到com.xxx.ExampleService这样的service, 通过修改Pattern匹配方式为不区分大小写，修复了该bug
3.主要为主页搜索相关的方法加了一些注释