### PR TITLE
Return BAD_REQUEST for parameter error

### DIFF
--- a/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/handler/CustomExceptionHandler.java
+++ b/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/handler/CustomExceptionHandler.java
@@ -24,6 +24,7 @@ import org.apache.dubbo.admin.common.exception.ServiceException;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -66,7 +67,8 @@ public class CustomExceptionHandler {
 
     @ResponseBody
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(value = {ParamValidationException.class})
+    @ExceptionHandler(value = {ParamValidationException.class,
+            ServletRequestBindingException.class})
     public CommonResponse paramValidationExceptionHandle(Exception e) {
         CommonResponse commonResponse = CommonResponse.createCommonResponse();
         logger.error("[ParamValidationException]Exception:", e);


### PR DESCRIPTION
Should return `HttpStatus.BAD_REQUEST` for bad parameter requests.
```
http 127.0.0.1:8080/api/dev/service
HTTP/1.1 500
Connection: close
Content-Type: application/json;charset=UTF-8
Date: Tue, 01 Jan 2019 06:00:51 GMT
Transfer-Encoding: chunked

{
    "message": "System Error, please try again later! Message:Required String parameter 'pattern' is not present",
    "success": false
}
```
should be
```
http 127.0.0.1:8080/api/dev/service
HTTP/1.1 400
Connection: close
Content-Type: application/json;charset=UTF-8
Date: Tue, 01 Jan 2019 06:01:27 GMT
Transfer-Encoding: chunked

{
    "message": "Parameter validation failure! Message:Required String parameter 'pattern' is not present",
    "success": false
}
```