### PR TITLE
Fix no such extension

### DIFF
--- a/dubbo-admin-backend/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.admin.data.config.GovernanceConfiguration
+++ b/dubbo-admin-backend/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.admin.data.config.GovernanceConfiguration
@@ -1,2 +1,0 @@
-zookeeper=org.apache.dubbo.admin.data.config.impl.ZookeeperConfiguration
-apollo=org.apache.dubbo.admin.data.config.impl.ZookeeperConfiguration

--- a/dubbo-admin-backend/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.admin.data.metadata.MetaDataCollector
+++ b/dubbo-admin-backend/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.admin.data.metadata.MetaDataCollector
@@ -1,2 +1,0 @@
-zookeeper=org.apache.dubbo.admin.data.metadata.impl.ZookeeperMetaDataCollector
-redis=org.apache.dubbo.admin.data.metadata.impl.RedisMetaDataCollector

--- a/dubbo-admin-backend/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.admin.registry.config.GovernanceConfiguration
+++ b/dubbo-admin-backend/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.admin.registry.config.GovernanceConfiguration
@@ -1,0 +1,2 @@
+zookeeper=org.apache.dubbo.admin.registry.config.impl.ZookeeperConfiguration
+apollo=org.apache.dubbo.admin.registry.config.impl.ApolloConfiguration

--- a/dubbo-admin-backend/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.admin.registry.metadata.MetaDataCollector
+++ b/dubbo-admin-backend/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.admin.registry.metadata.MetaDataCollector
@@ -1,0 +1,2 @@
+zookeeper=org.apache.dubbo.admin.registry.metadata.impl.ZookeeperMetaDataCollector
+redis=org.apache.dubbo.admin.registry.metadata.impl.RedisMetaDataCollector


### PR DESCRIPTION
fix no such extension after refactor
```
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.apache.dubbo.admin.registry.config.GovernanceConfiguration]: Factory method 'getDynamicConfiguration' threw exception; nested exceptio
n is java.lang.IllegalStateException: No such extension org.apache.dubbo.admin.registry.config.GovernanceConfiguration by name zookeeper
```

please start backend server to check this