### PR TITLE
Tweak ZookeeperConfiguration

### DIFF
--- a/dubbo-admin-backend/pom.xml
+++ b/dubbo-admin-backend/pom.xml
@@ -92,6 +92,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
         </dependency>

--- a/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/registry/config/impl/ZookeeperConfiguration.java
+++ b/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/registry/config/impl/ZookeeperConfiguration.java
@@ -17,18 +17,16 @@
 
 package org.apache.dubbo.admin.registry.config.impl;
 
+import org.apache.dubbo.admin.common.util.Constants;
+import org.apache.dubbo.admin.registry.config.GovernanceConfiguration;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
-import org.apache.dubbo.admin.common.util.Constants;
-import org.apache.dubbo.admin.registry.config.GovernanceConfiguration;
-import org.apache.dubbo.common.logger.Logger;
-import org.apache.dubbo.common.logger.LoggerFactory;
-import org.apache.dubbo.common.URL;
-
-import java.security.acl.Group;
-
 
 public class ZookeeperConfiguration implements GovernanceConfiguration {
     private static final Logger logger = LoggerFactory.getLogger(ZookeeperConfiguration.class);
@@ -48,10 +46,13 @@ public class ZookeeperConfiguration implements GovernanceConfiguration {
 
     @Override
     public void init() {
+        if (url == null) {
+            throw new IllegalStateException("server url is null, cannot init");
+        }
         CuratorFrameworkFactory.Builder zkClientBuilder = CuratorFrameworkFactory.builder().
                 connectString(url.getAddress()).
                 retryPolicy(new ExponentialBackoffRetry(1000, 3));
-        if(StringUtils.isNotEmpty(url.getUsername()) && StringUtils.isNotEmpty(url.getPassword())){
+        if (StringUtils.isNotEmpty(url.getUsername()) && StringUtils.isNotEmpty(url.getPassword())) {
             // add authorization
             String auth = url.getUsername() + ":" + url.getPassword();
             zkClientBuilder.authorization("digest", auth.getBytes());
@@ -82,6 +83,9 @@ public class ZookeeperConfiguration implements GovernanceConfiguration {
 
     @Override
     public String setConfig(String group, String key, String value) {
+        if (key == null || value == null) {
+            throw new IllegalArgumentException("key or value cannot be null");
+        }
         String path = getNodePath(key, group);
         try {
             if (zkClient.checkExists().forPath(path) == null) {
@@ -97,6 +101,9 @@ public class ZookeeperConfiguration implements GovernanceConfiguration {
 
     @Override
     public String getConfig(String group, String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key cannot be null");
+        }
         String path = getNodePath(key, group);
 
         try {
@@ -112,11 +119,15 @@ public class ZookeeperConfiguration implements GovernanceConfiguration {
 
     @Override
     public boolean deleteConfig(String group, String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key cannot be null");
+        }
         String path = getNodePath(key, group);
         try {
             zkClient.delete().forPath(path);
         } catch (Exception e) {
             logger.error(e.getMessage(), e);
+            return false;
         }
         return true;
     }
@@ -132,6 +143,9 @@ public class ZookeeperConfiguration implements GovernanceConfiguration {
     }
 
     private String getNodePath(String path, String group) {
+        if (path == null) {
+            throw new IllegalArgumentException("path cannot be null");
+        }
         return toRootDir(group) + path;
     }
 

--- a/dubbo-admin-backend/src/test/java/org/apache/dubbo/admin/registry/config/impl/ZookeeperConfigurationTest.java
+++ b/dubbo-admin-backend/src/test/java/org/apache/dubbo/admin/registry/config/impl/ZookeeperConfigurationTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.admin.registry.config.impl;
+
+import org.apache.dubbo.admin.common.util.Constants;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.NetUtils;
+
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class ZookeeperConfigurationTest {
+
+    private TestingServer zkServer;
+    private ZookeeperConfiguration configuration;
+    private URL registryUrl;
+
+    @Before
+    public void setup() throws Exception {
+        int zkServerPort = NetUtils.getAvailablePort();
+        zkServer = new TestingServer(zkServerPort, true);
+        registryUrl = URL.valueOf("zookeeper://localhost:" + zkServerPort);
+
+        configuration = new ZookeeperConfiguration();
+        try {
+            configuration.init();
+            fail("init should fail before setting registryUrl");
+        } catch (IllegalStateException e) {
+        }
+
+        configuration.setUrl(registryUrl);
+        configuration.init();
+    }
+
+    @Test
+    public void testGetSetConfig() {
+        configuration.setConfig("test_key", "test_value");
+        assertEquals("test_value", configuration.getConfig("test_key"));
+        assertEquals(null, configuration.getConfig("not_exist_key"));
+
+
+        configuration.setConfig("test_group", "test_key", "test_group_value");
+        assertEquals("test_group_value", configuration.getConfig("test_group", "test_key"));
+
+        assertEquals(null, configuration.getConfig("test_group", "not_exist_key"));
+
+        try {
+            configuration.getConfig(null);
+            fail("should throw IllegalArgumentException for null key");
+        } catch (IllegalArgumentException e) {
+        }
+        try {
+            configuration.setConfig("test_null", null);
+            fail("should throw IllegalArgumentException for null key");
+        } catch (IllegalArgumentException e) {
+        }
+    }
+
+    @Test
+    public void testDeleteConfig() {
+        assertEquals(false, configuration.deleteConfig("not_exist_key"));
+        configuration.setConfig("test_delete", "test_value");
+        assertEquals("test_value", configuration.getConfig("test_delete"));
+        configuration.deleteConfig("test_delete");
+        assertEquals(null, configuration.getConfig("test_delete"));
+
+        assertEquals(false, configuration.deleteConfig("test_group", "not_exist_key"));
+        configuration.setConfig("test_group", "test_delete", "test_value");
+        assertEquals("test_value", configuration.getConfig("test_group", "test_delete"));
+        configuration.deleteConfig("test_group", "test_delete");
+        assertEquals(null, configuration.getConfig("test_group", "test_delete"));
+
+        try {
+            configuration.deleteConfig(null);
+            fail("should throw IllegalArgumentException for null key");
+        } catch (IllegalArgumentException e) {
+        }
+    }
+
+    @Test
+    public void testGetPath() {
+        assertEquals(Constants.PATH_SEPARATOR + Constants.DEFAULT_ROOT + Constants.PATH_SEPARATOR + "test_key",
+                configuration.getPath("test_key"));
+        try {
+            configuration.getPath(null);
+            fail("should throw IllegalArgumentException for null path");
+        } catch (IllegalArgumentException e) {
+        }
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        zkServer.stop();
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <commons-lang3-version>3.7</commons-lang3-version>
 		<dubbo-version>2.7.0-SNAPSHOT</dubbo-version>
 		<curator-version>2.12.0</curator-version>
+		<curator-test-version>2.12.0</curator-test-version>
 		<fastjson-version>1.2.46</fastjson-version>
 		<springfox-swagger-version>2.9.2</springfox-swagger-version>
 		<netty-version>4.1.30.Final</netty-version>
@@ -102,6 +103,13 @@
 				<artifactId>curator-framework</artifactId>
 				<version>${curator-version}</version>
 			</dependency>
+
+			<dependency>
+				<groupId>org.apache.curator</groupId>
+				<artifactId>curator-test</artifactId>
+				<version>${curator-test-version}</version>
+			</dependency>
+
 			<dependency>
 				<groupId>com.alibaba</groupId>
 				<artifactId>fastjson</artifactId>


### PR DESCRIPTION
### brief changes
- Add null parameter check for `key` and `path`
- Return false if exception thrown in `zkClient.delete().forPath(path);`
- Remove unused import which may introduce compile warning `import java.security.acl.Group;`
- Add unit test for ZookeeperConfiguration #216 