### PR TITLE
externalize configuration properties and change to yml format

### DIFF
--- a/dubbo-admin-backend/pom.xml
+++ b/dubbo-admin-backend/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -126,6 +131,7 @@
             <artifactId>mockito-core</artifactId>
             <version>${mockito-version}</version>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/DubboAdminProperties.java
+++ b/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/DubboAdminProperties.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.admin;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "admin")
+public class DubboAdminProperties {
+  private ConfigCenter configCenter;
+  private Registry registry;
+  private Metadata metadata;
+  private Apollo apollo;
+
+  public ConfigCenter getConfigCenter() {
+    return configCenter;
+  }
+
+  public void setConfigCenter(final ConfigCenter configCenter) {
+    this.configCenter = configCenter;
+  }
+
+  public Registry getRegistry() {
+    return registry;
+  }
+
+  public void setRegistry(final Registry registry) {
+    this.registry = registry;
+  }
+
+  public Metadata getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(final Metadata metadata) {
+    this.metadata = metadata;
+  }
+
+  public Apollo getApollo() {
+    return apollo;
+  }
+
+  public void setApollo(final Apollo apollo) {
+    this.apollo = apollo;
+  }
+
+  public static class ConfigCenter {
+    private String address;
+    private String username;
+    private String password;
+
+    public String getAddress() {
+      return address;
+    }
+
+    public void setAddress(final String address) {
+      this.address = address;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+
+    public void setUsername(final String username) {
+      this.username = username;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public void setPassword(final String password) {
+      this.password = password;
+    }
+  }
+
+  public static class Registry {
+    private String address;
+    private String group;
+
+    public String getAddress() {
+      return address;
+    }
+
+    public void setAddress(final String address) {
+      this.address = address;
+    }
+
+    public String getGroup() {
+      return group;
+    }
+
+    public void setGroup(final String group) {
+      this.group = group;
+    }
+  }
+
+  public static class Metadata {
+    private String address;
+
+    public String getAddress() {
+      return address;
+    }
+
+    public void setAddress(final String address) {
+      this.address = address;
+    }
+  }
+
+  public static class Apollo {
+    private String token;
+    private String appId;
+    private String env;
+    private String cluster;
+    private String namespace;
+
+    public String getToken() {
+      return token;
+    }
+
+    public void setToken(final String token) {
+      this.token = token;
+    }
+
+    public String getAppId() {
+      return appId;
+    }
+
+    public void setAppId(final String appId) {
+      this.appId = appId;
+    }
+
+    public String getEnv() {
+      return env;
+    }
+
+    public void setEnv(final String env) {
+      this.env = env;
+    }
+
+    public String getCluster() {
+      return cluster;
+    }
+
+    public void setCluster(final String cluster) {
+      this.cluster = cluster;
+    }
+
+    public String getNamespace() {
+      return namespace;
+    }
+
+    public void setNamespace(final String namespace) {
+      this.namespace = namespace;
+    }
+  }
+
+}

--- a/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/config/ConfigCenter.java
+++ b/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/config/ConfigCenter.java
@@ -18,19 +18,18 @@
 package org.apache.dubbo.admin.config;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.dubbo.admin.DubboAdminProperties;
 import org.apache.dubbo.admin.common.exception.ConfigurationException;
 import org.apache.dubbo.admin.common.util.Constants;
 import org.apache.dubbo.admin.registry.config.GovernanceConfiguration;
 import org.apache.dubbo.admin.registry.metadata.MetaDataCollector;
 import org.apache.dubbo.admin.registry.metadata.impl.NoOpMetadataCollector;
-import org.apache.dubbo.admin.service.ManagementService;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.registry.Registry;
 import org.apache.dubbo.registry.RegistryFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,28 +40,13 @@ import java.util.Arrays;
 
 @Configuration
 public class ConfigCenter {
-
-
-
-    //centers in dubbo 2.7
-    @Value("${admin.config-center:}")
+    // centers in dubbo 2.7
     private String configCenter;
-
-    @Value("${admin.registry.address:}")
     private String registryAddress;
-
-    @Value("${admin.metadata.address:}")
     private String metadataAddress;
-
-    @Value("${admin.registry.group:}")
     private String group;
-
-    @Value("${admin.config-center.username:}")
     private String username;
-    @Value("${admin.config-center.password:}")
     private String password;
-
-    private static String globalConfigPath = "config/dubbo/dubbo.properties";
 
     private static final Logger logger = LoggerFactory.getLogger(ConfigCenter.class);
 
@@ -70,6 +54,14 @@ public class ConfigCenter {
     private URL registryUrl;
     private URL metadataUrl;
 
+    public ConfigCenter(final DubboAdminProperties dubboAdminProperties) {
+        configCenter = dubboAdminProperties.getConfigCenter().getAddress();
+        registryAddress = dubboAdminProperties.getRegistry().getAddress();
+        metadataAddress = dubboAdminProperties.getMetadata().getAddress();
+        group = dubboAdminProperties.getRegistry().getGroup();
+        username = dubboAdminProperties.getConfigCenter().getUsername();
+        password = dubboAdminProperties.getConfigCenter().getPassword();
+    }
 
 
     /*
@@ -84,7 +76,7 @@ public class ConfigCenter {
             dynamicConfiguration = ExtensionLoader.getExtensionLoader(GovernanceConfiguration.class).getExtension(configCenterUrl.getProtocol());
             dynamicConfiguration.setUrl(configCenterUrl);
             dynamicConfiguration.init();
-            String config = dynamicConfiguration.getConfig(globalConfigPath);
+            String config = dynamicConfiguration.getConfig(Constants.GLOBAL_CONFIG_PATH);
 
             if (StringUtils.isNotEmpty(config)) {
                 Arrays.stream(config.split("\n")).forEach( s -> {

--- a/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/registry/config/impl/ApolloConfiguration.java
+++ b/dubbo-admin-backend/src/main/java/org/apache/dubbo/admin/registry/config/impl/ApolloConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.admin.registry.config.impl;
 
 import com.ctrip.framework.apollo.openapi.client.ApolloOpenApiClient;
 import com.ctrip.framework.apollo.openapi.dto.OpenItemDTO;
+import org.apache.dubbo.admin.DubboAdminProperties;
 import org.apache.dubbo.admin.registry.config.GovernanceConfiguration;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.SPI;
@@ -26,25 +27,23 @@ import org.springframework.beans.factory.annotation.Value;
 
 @SPI("apollo")
 public class ApolloConfiguration implements GovernanceConfiguration {
-
-    @Value("${admin.apollo.token}")
     private String token;
-
-    @Value("${admin.apollo.cluster}")
     private String cluster;
-
-    @Value("${admin.apollo.namespace}")
     private String namespace;
-
-    @Value("${admin.apollo.env}")
     private String env;
-
-    @Value("${admin.apollo.appId}")
     private String appId;
 
     private URL url;
     private ApolloOpenApiClient client;
 
+    public ApolloConfiguration(final DubboAdminProperties dubboAdminProperties) {
+        token = dubboAdminProperties.getApollo().getToken();
+        cluster = dubboAdminProperties.getApollo().getCluster();
+        namespace = dubboAdminProperties.getApollo().getNamespace();
+        env = dubboAdminProperties.getApollo().getEnv();
+        appId = dubboAdminProperties.getApollo().getAppId();
+
+    }
 
     @Override
     public void setUrl(URL url) {

--- a/dubbo-admin-backend/src/main/resources/application-test.yml
+++ b/dubbo-admin-backend/src/main/resources/application-test.yml
@@ -15,7 +15,10 @@
 # limitations under the License.
 #
 
-# centers in dubbo2.7
-admin.registry.address=zookeeper://127.0.0.1:2182
-admin.config-center=zookeeper://127.0.0.1:2182
-admin.metadata.address=zookeeper://127.0.0.1:2182
+admin:
+  registry:
+    address: zookeeper://127.0.0.1:2182
+  config-center:
+    address: zookeeper://127.0.0.1:2182
+  metadata:
+    address: zookeeper://127.0.0.1:2182

--- a/dubbo-admin-backend/src/main/resources/application.yml
+++ b/dubbo-admin-backend/src/main/resources/application.yml
@@ -15,16 +15,17 @@
 # limitations under the License.
 #
 
-# centers in dubbo2.7
-admin.registry.address=zookeeper://127.0.0.1:2181
-admin.config-center=zookeeper://127.0.0.1:2181
-admin.metadata.address=zookeeper://127.0.0.1:2181
-
-
-
-admin.registry.group=dubbo
-admin.apollo.token=e16e5cd903fd0c97a116c873b448544b9d086de9
-admin.apollo.appId=test
-admin.apollo.env=dev
-admin.apollo.cluster=default
-admin.apollo.namespace=dubbo
+admin:
+  registry:
+    address: zookeeper://127.0.0.1:2181
+    group: dubbo
+  config-center:
+    address: zookeeper://127.0.0.1:2181
+  metadata:
+    address: zookeeper://127.0.0.1:2181
+  apollo:
+    env: dev
+    app-id: test
+    cluster: default
+    namespace: dubbo
+    token: e16e5cd903fd0c97a116c873b448544b9d086de9


### PR DESCRIPTION
This patch uses the configuration-processor of Spring Boot and change to YML format, with this patch:

- configurations become type safer and more friendly:
![image](https://user-images.githubusercontent.com/15965696/51542322-ec9a3400-1e95-11e9-9e45-fabddab8e196.png)

- autocompletion is at hand in modern IDE:
![image](https://user-images.githubusercontent.com/15965696/51542206-a513a800-1e95-11e9-867f-fd8702cb8e20.png)

- configuring is more convenient when configuring complex object (like array)