### PR TITLE
Cleanup registry info after controller test cases (#291)

### DIFF
--- a/dubbo-admin-backend/src/test/java/org/apache/dubbo/admin/controller/AccessesControllerTest.java
+++ b/dubbo-admin-backend/src/test/java/org/apache/dubbo/admin/controller/AccessesControllerTest.java
@@ -24,6 +24,8 @@ import org.apache.dubbo.admin.model.dto.AccessDTO;
 import org.apache.dubbo.admin.model.dto.ConditionRouteDTO;
 import org.apache.dubbo.admin.service.ProviderService;
 import org.apache.dubbo.admin.service.RouteService;
+
+import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -51,6 +53,13 @@ public class AccessesControllerTest extends AbstractSpringIntegrationTest {
     private ProviderService providerService;
     @Autowired
     private ObjectMapper objectMapper;
+
+    @After
+    public void tearDown() throws Exception {
+        if (zkClient.checkExists().forPath("/dubbo") != null) {
+            zkClient.delete().deletingChildrenIfNeeded().forPath("/dubbo");
+        }
+    }
 
     @Test
     public void searchAccess() throws IOException {

--- a/dubbo-admin-backend/src/test/java/org/apache/dubbo/admin/controller/LoadBalanceControllerTest.java
+++ b/dubbo-admin-backend/src/test/java/org/apache/dubbo/admin/controller/LoadBalanceControllerTest.java
@@ -22,6 +22,8 @@ import org.apache.dubbo.admin.AbstractSpringIntegrationTest;
 import org.apache.dubbo.admin.model.dto.BalancingDTO;
 import org.apache.dubbo.admin.service.OverrideService;
 import org.apache.dubbo.admin.service.ProviderService;
+
+import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -55,6 +57,13 @@ public class LoadBalanceControllerTest extends AbstractSpringIntegrationTest {
     private ProviderService providerService;
     @Autowired
     private ObjectMapper objectMapper;
+
+    @After
+    public void tearDown() throws Exception {
+        if (zkClient.checkExists().forPath("/dubbo") != null) {
+            zkClient.delete().deletingChildrenIfNeeded().forPath("/dubbo");
+        }
+    }
 
     @Test
     public void createLoadbalance() throws IOException {

--- a/dubbo-admin-backend/src/test/java/org/apache/dubbo/admin/controller/ManagementControllerTest.java
+++ b/dubbo-admin-backend/src/test/java/org/apache/dubbo/admin/controller/ManagementControllerTest.java
@@ -21,6 +21,8 @@ import org.apache.dubbo.admin.AbstractSpringIntegrationTest;
 import org.apache.dubbo.admin.common.util.Constants;
 import org.apache.dubbo.admin.model.dto.ConfigDTO;
 import org.apache.dubbo.admin.service.ProviderService;
+
+import org.junit.After;
 import org.junit.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.ParameterizedTypeReference;
@@ -44,6 +46,13 @@ public class ManagementControllerTest extends AbstractSpringIntegrationTest {
 
   @MockBean
   private ProviderService providerService;
+
+  @After
+  public void tearDown() throws Exception {
+    if (zkClient.checkExists().forPath("/dubbo") != null) {
+      zkClient.delete().deletingChildrenIfNeeded().forPath("/dubbo");
+    }
+  }
 
   @Test
   public void shouldCreateGlobalConfig() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

Fix issue #291 

If some controller test class run before `ServiceControllerTest`, it may fail.

This can be reproduced by:
```
mvn test -rf dubbo-admin-backend -Dtest="**.LoadBalance*Test,**.Service*Test"
``` 

## Brief changelog

Cleanup registry info after those controller test classes. 

## Verifying this change
This should pass:
```
mvn test -rf dubbo-admin-backend -Dtest="**.LoadBalance*Test,**.Service*Test"
```